### PR TITLE
Allow manual expense amount input and validation

### DIFF
--- a/src/components/dashboard/AdminDashboard.tsx
+++ b/src/components/dashboard/AdminDashboard.tsx
@@ -26,6 +26,7 @@ export function AdminDashboard() {
   const [dateRange, setDateRange] = useState<{ startDate?: Date; endDate?: Date }>({});
   const [isFastReceptionistOpen, setIsFastReceptionistOpen] = useState(false);
   const [isExpenseOpen, setIsExpenseOpen] = useState(false);
+  const [amountText, setAmountText] = useState<string>("");
   const [expenseForm, setExpenseForm] = useState<CreateExpenseData>({
     description: "",
     amount: 0,
@@ -71,6 +72,7 @@ export function AdminDashboard() {
       payment_method: "cash",
       notes: "",
     });
+    setAmountText("");
   };
 
   const createExpenseMutation = useMutation({
@@ -179,13 +181,18 @@ export function AdminDashboard() {
             <div>
               <Label>المبلغ (LE) *</Label>
               <Input
-                type="number"
-                min="0"
-                step="0.01"
-                value={expenseForm.amount}
-                onChange={(e) =>
-                  setExpenseForm((prev) => ({ ...prev, amount: Number(e.target.value) || 0 }))
-                }
+                type="text"
+                inputMode="decimal"
+                pattern="[0-9]*[.,]?[0-9]*"
+                value={amountText}
+                onChange={(e) => {
+                  const raw = e.target.value.replace(/[^0-9.,]/g, '');
+                  setAmountText(raw);
+                  const normalized = raw.replace(',', '.');
+                  const parsed = parseFloat(normalized);
+                  setExpenseForm((prev) => ({ ...prev, amount: isNaN(parsed) ? 0 : parsed }));
+                }}
+                placeholder="أدخل المبلغ"
               />
             </div>
             <div>


### PR DESCRIPTION
Update the expense amount input to allow manual keyboard entry, removing the counter and adding numeric validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-135f4e00-68a3-4ede-b374-f06728a3d146">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-135f4e00-68a3-4ede-b374-f06728a3d146">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

