### PR TITLE
Fix duplicated side navigation bar

### DIFF
--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -9,7 +9,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
-import { UnifiedLayout } from '@/components/layout/UnifiedLayout';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { exportExpensesToExcel } from "@/utils/exportUtils";
 import { cn } from "@/lib/utils";
@@ -211,7 +210,6 @@ export default function ExpensesPage() {
   };
 
   return (
-    <UnifiedLayout>
       <div className="py-8 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold">إدارة المصروفات</h1>
@@ -509,7 +507,6 @@ export default function ExpensesPage() {
           </DialogContent>
         </Dialog>
       </div>
-    </UnifiedLayout>
   );
 }
 


### PR DESCRIPTION
Prevent duplicate side navigation bar by adding a global guard to `UnifiedLayout` and removing redundant page-level wrappers.

The issue arose because both the router and individual pages were wrapping content with `UnifiedLayout`, leading to a nested and duplicated sidebar. The guard ensures only one top-level layout is applied, resolving the double rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3c1fd35-9f9a-484e-9e4f-0eb9a586815b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3c1fd35-9f9a-484e-9e4f-0eb9a586815b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

